### PR TITLE
Porechop and Dragonflye changes

### DIFF
--- a/conf/resources.config
+++ b/conf/resources.config
@@ -1,7 +1,7 @@
 process {
   withName: 'nanopore:ASSEMBLY_nanopore:dragonflye' {
     cpus = 6
-    memory = 9.GB
+    memory = 16.GB
   }
   withName: 'nanopore:ASSEMBLY_nanopore:metaflye' {
     cpus = 6

--- a/conf/singularity.config
+++ b/conf/singularity.config
@@ -1,6 +1,6 @@
 process {
     withName:porechop {
-        container = 'docker://biocontainers/porechop'
+        container = 'https://depot.galaxyproject.org/singularity/porechop:0.2.4--py39h7cff6ad_2'
     }
     withName:metaflye {
         container = 'docker://staphb/flye:2.9.2'


### PR DESCRIPTION
- porechop container change to fix `Command 'ps' required by nextflow to collect task metrics cannot be found`
- dragonflye process change to alleviate out-of-memory errors